### PR TITLE
Update README.md to be clearer of the intent of repo & more explicitly refer to the source material.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JS-stroll
 
-This repo is comprised of tiny JavaScript and SVG excercises for generative effects. Most code exercises in this repo are from [*The Nature of Code*](http://natureofcode.com/), originally written in [Processing](https://processing.org/); The code is rewritten in JavaScript to solidify the underlying concepts.
+This repo is comprised of tiny JavaScript and SVG excercises for generative effects. Most code exercises in this repo are from [*The Nature of Code*](http://natureofcode.com/), originally written in [Processing](https://processing.org/); the code is rewritten in JavaScript to solidify the underlying concepts.
 
 Other code exercises in this repo are from Rachel Smith's *Hack Physics with JavaScript* series of posts ([Part 1](https://codepen.io/rachsmith/post/hack-physics-and-javascript-1), [Part 2](https://codepen.io/rachsmith/post/hack-physics-and-javascript-part-2-solving-triangles-profit), & [Part 3](https://codepen.io/rachsmith/post/hack-physics-and-javascript-part-3-springs-and-some-other-things)); the code is rewritten in SVG and JavaScript instead of leveraging Canvas and JavaScript.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # JS-stroll
 
-This repo is comprised of tiny JavaScript and SVG excercises for generative effects. Rewriting code from 'The Nature of Code', originally written in Processing, in JavaScript to solidify the unerlying concepts. Also rewriting Rachel Smith's Hack Physics with JavaScript posts in SVG and vanilla JS (originals are in Canvas). Commented at the top of the main.js file of every directory is the url to the original code as well as a codepen demo of the output.
+This repo is comprised of tiny JavaScript and SVG excercises for generative effects. Most code exercises in this repo are from [*The Nature of Code*](http://natureofcode.com/), originally written in [Processing](https://processing.org/); The code is rewritten in JavaScript to solidify the underlying concepts.
+
+Other code exercises in this repo are from Rachel Smith's *Hack Physics with JavaScript* series of posts ([Part 1](https://codepen.io/rachsmith/post/hack-physics-and-javascript-1), [Part 2](https://codepen.io/rachsmith/post/hack-physics-and-javascript-part-2-solving-triangles-profit), & [Part 3](https://codepen.io/rachsmith/post/hack-physics-and-javascript-part-3-springs-and-some-other-things)); The code is rewritten in SVG and JavaScript; instead of leveraging Canvas and JavaScript.
+
+Commented at the top of the main.js file of every directory is the URL to the original code exercises as well as a codepen demo of the output.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 This repo is comprised of tiny JavaScript and SVG excercises for generative effects. Most code exercises in this repo are from [*The Nature of Code*](http://natureofcode.com/), originally written in [Processing](https://processing.org/); The code is rewritten in JavaScript to solidify the underlying concepts.
 
-Other code exercises in this repo are from Rachel Smith's *Hack Physics with JavaScript* series of posts ([Part 1](https://codepen.io/rachsmith/post/hack-physics-and-javascript-1), [Part 2](https://codepen.io/rachsmith/post/hack-physics-and-javascript-part-2-solving-triangles-profit), & [Part 3](https://codepen.io/rachsmith/post/hack-physics-and-javascript-part-3-springs-and-some-other-things)); The code is rewritten in SVG and JavaScript; instead of leveraging Canvas and JavaScript.
+Other code exercises in this repo are from Rachel Smith's *Hack Physics with JavaScript* series of posts ([Part 1](https://codepen.io/rachsmith/post/hack-physics-and-javascript-1), [Part 2](https://codepen.io/rachsmith/post/hack-physics-and-javascript-part-2-solving-triangles-profit), & [Part 3](https://codepen.io/rachsmith/post/hack-physics-and-javascript-part-3-springs-and-some-other-things)); the code is rewritten in SVG and JavaScript instead of leveraging Canvas and JavaScript.
 
 Commented at the top of the main.js file of every directory is the URL to the original code exercises as well as a codepen demo of the output.


### PR DESCRIPTION
# PR Goals
- [x] Make clearer references to the "The Nature of Coding" source material for other curious readers such as myself 
- [x] Make clearer references to Rachel Smith's Posts for other curious readers such as myself
- [x] Correct typos associated with technology acronyms not capitalized
- [x] Clean-up potentially confusing references to JavaScript in a variety of ways that are seemingly unneeded as no DSLs or framework-specific JavaScript abstractions are associated with this repo yet (i.e. remove references of "vanilla JS", "JS",  & JavaScript, using just JavaScript) 
## PR Side-effects
- The readme is ultimately longer; I think it's a superficial sideeffect. 
- From one  paragraph, the `README.md` is now 3 paragraphs. I believe this is also an okay side-effect; I'm of the opinion that this reads much better and the new paragraphs provide very distinct train of thoughts
## Estimated Review Time

I estimate it'll take 2-5 minutes to review this PR. 
## Recommended Reviewers

Drasner-san
